### PR TITLE
Update lib.rs

### DIFF
--- a/svg_fmt/src/lib.rs
+++ b/svg_fmt/src/lib.rs
@@ -1,5 +1,5 @@
 mod svg;
 mod layout;
 
-pub use svg::*;
-pub use layout::*;
+pub use self::svg::*;
+pub use self::layout::*;


### PR DESCRIPTION
Otherwise it does not compile on mac with rust 1.31.1

error[E0432]: unresolved import `svg`
 --> svg_fmt-0.4.0/src/lib.rs:4:9
  |
4 | pub use svg::*;
  |         ^^^ Did you mean `self::svg`?

error[E0432]: unresolved import `layout`
 -->svg_fmt-0.4.0/src/lib.rs:5:9
  |
5 | pub use layout::*;
  |         ^^^^^^ Did you mean `self::layout`?