### PR TITLE
Remove trailing "s in output

### DIFF
--- a/svg_fmt/src/svg.rs
+++ b/svg_fmt/src/svg.rs
@@ -185,7 +185,7 @@ impl fmt::Display for Rectangle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            r#"<rect x="{}" y="{}" width="{}" height="{}" ry="{}" style="{}" />""#,
+            r#"<rect x="{}" y="{}" width="{}" height="{}" ry="{}" style="{}" />"#,
             self.x, self.y, self.w, self.h, self.border_radius, self.style,
         )
     }
@@ -248,7 +248,7 @@ impl fmt::Display for Circle {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            r#"<circle cx="{}" cy="{}" r="{}" style="{}" />""#,
+            r#"<circle cx="{}" cy="{}" r="{}" style="{}" />"#,
             self.x, self.y, self.radius, self.style,
         )
     }


### PR DESCRIPTION
There is trailing `"`s in the created svg. This PR removes them.