### PR TITLE
`#![no_std]` for `svg_fmt`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
-*/target
+**/target
 **/*.rs.bk
 */Cargo.lock
+
+.idea

--- a/svg_fmt/src/lib.rs
+++ b/svg_fmt/src/lib.rs
@@ -1,3 +1,6 @@
+#![no_std]
+extern crate alloc;
+
 mod layout;
 mod svg;
 

--- a/svg_fmt/src/svg.rs
+++ b/svg_fmt/src/svg.rs
@@ -1,4 +1,6 @@
-use std::fmt;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::fmt;
 
 /// `rgb({r},{g},{b})`
 #[derive(Copy, Clone, PartialEq)]
@@ -790,21 +792,4 @@ impl fmt::Display for Indentation {
         }
         Ok(())
     }
-}
-
-#[test]
-fn foo() {
-    println!("{}", BeginSvg { w: 800.0, h: 600.0 });
-    println!(
-        "    {}",
-        rectangle(20.0, 50.0, 200.0, 100.0)
-            .fill(red())
-            .stroke(Stroke::Color(black(), 3.0))
-            .border_radius(5.0)
-    );
-    println!(
-        "    {}",
-        text(25.0, 100.0, "Foo!").size(42.0).color(white())
-    );
-    println!("{}", EndSvg);
 }

--- a/svg_fmt/tests/display.rs
+++ b/svg_fmt/tests/display.rs
@@ -1,0 +1,18 @@
+use svg_fmt::{black, rectangle, red, text, white, BeginSvg, EndSvg, Stroke};
+
+#[test]
+fn foo() {
+    println!("{}", BeginSvg { w: 800.0, h: 600.0 });
+    println!(
+        "    {}",
+        rectangle(20.0, 50.0, 200.0, 100.0)
+            .fill(red())
+            .stroke(Stroke::Color(black(), 3.0))
+            .border_radius(5.0)
+    );
+    println!(
+        "    {}",
+        text(25.0, 100.0, "Foo!").size(42.0).color(white())
+    );
+    println!("{}", EndSvg);
+}


### PR DESCRIPTION
Opts out of `std` for `svg_fmt`, and moved the test into `tests/` directory so it can use `println!`.
This is intended to be followed up with `#![no_std]` for `guillotiere`.